### PR TITLE
Replace relative file:// urls with absolute path.

### DIFF
--- a/src/previewContentProvider.ts
+++ b/src/previewContentProvider.ts
@@ -58,6 +58,11 @@ export default class PreviewContentProvider implements vscode.TextDocumentConten
             let html = mjml2html(vscode.window.activeTextEditor.document.getText(), { level: 'skip', disableMinify: true });
 
             if (html.html) {
+
+                const documentAbsoluteDir = path.dirname(vscode.window.activeTextEditor.document.uri.fsPath)
+                //replace relative file links with absolute, to correctly render images!
+                html.html = html.html.replace(/file:\/\/(?!\/)/g,'file://'+documentAbsoluteDir+'/')
+
                 return html.html;
             }
         }


### PR DESCRIPTION
Simple workaround to make relative file:// images work.

It replaces every occurrence `file://relative/path/file` with `file://absolutepath/relative/path/file`. It will ignore it if it is a absolute path already (ie: `file:///abs/path/file`)

Regex could be additionally restricted to only check in specific attributes. However it should rarely happen that someone has a file:// in a text