### PR TITLE
Add cwd for .mjmlconfig support

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -14,7 +14,8 @@ export default class Helper {
                 level: 'skip',
                 minify: minify,
                 beautify: beautify,
-                filePath: vscode.window.activeTextEditor.document.uri.fsPath
+                filePath: vscode.window.activeTextEditor.document.uri.fsPath,
+                cwd: vscode.workspace.rootPath
             });
 
             if (html.html) {


### PR DESCRIPTION
Partly fixes the problem in #5.

Fixes rendering, but still linting errors until you run render or preview.

Passes in the VSCode workspace dir as `cwd` which is picked up [here]( https://github.com/mjmlio/mjml/blob/eeaea68d1c5f0c0c7174ba06e8839baa2e65cb5f/packages/mjml-core/src/parsers/config.js#L18).

Which in turn then can find the `.mjmlconfig` file. This presupposes that your `.mjmlconfig` file is at the root of the current workspace directory of course.

I haven't worked a whole lot with VSCode extensions before though, so might be a better way to do this?